### PR TITLE
Update Miami2025 dataset registration to use AutoDL paths

### DIFF
--- a/datasets/register_miami2025.py
+++ b/datasets/register_miami2025.py
@@ -1,226 +1,164 @@
-"""Dataset registration for the miami2025 referring segmentation dataset."""
+"""
+Dataset registration for 'miami2025' using the real AutoDL data layout.
+
+Real data layout (AutoDL):
+/autodl-tmp/rela_data/
+├── annotations/
+│   ├── miami2025.json
+│   └── instances.json
+└── images/
+    ├── train2014/
+    └── val2014/
+
+Notes
+-----
+- By default this script uses the real files under /autodl-tmp/rela_data/annotations/.
+- You can override the instances path with env var MIAMI_INST_JSON:
+    export MIAMI_INST_JSON=/autodl-tmp/rela_data/annotations/instances.json
+- Image subdirs are mapped as:
+    train -> train2014
+    val   -> val2014
+    testA -> val2014   (common practice: use val images)
+    testB -> val2014
+"""
 
 import json
-import logging
 import os
-from typing import Any, Dict, Iterable, List, Optional
-
+from typing import List, Dict, Any
 from detectron2.data import DatasetCatalog, MetadataCatalog
 
-LOGGER = logging.getLogger(__name__)
 
-
-def _load_json_file(json_path: str) -> Any:
-    with open(json_path, "r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def _safe_get(dictionary: Dict[str, Any], key: str, default: Any = None) -> Any:
-    value = dictionary.get(key, default)
-    if value is None:
-        return default
-    return value
-
-
-def _ensure_iterable(value: Any) -> Iterable[Any]:
-    if isinstance(value, (list, tuple)):
-        return value
-    return [value]
-
-
-def _resolve_annotation_path(root: str, filename: str) -> Optional[str]:
-    candidates = [
-        os.path.join(root, filename),
-        os.path.join(os.path.dirname(root), filename),
-    ]
-    for candidate in candidates:
-        if os.path.isfile(candidate):
-            return candidate
-    return None
+def _build_id_maps(inst_data: Dict[str, Any]):
+    anns = inst_data.get("annotations", [])
+    imgs = inst_data.get("images", [])
+    id2ann = {a["id"]: a for a in anns}
+    id2img = {img["id"]: img for img in imgs}
+    return id2ann, id2img
 
 
 def load_miami2025_json(
     json_file: str,
     image_root: str,
     inst_json: str,
-    target_split: str,
+    target_split: str
 ) -> List[Dict[str, Any]]:
-    """Load the miami2025 dataset in Detectron2 format."""
-    dataset_entries = _load_json_file(json_file)
-    if not isinstance(dataset_entries, list):
-        raise ValueError(
-            f"Expected a list of dataset entries in {json_file}, got {type(dataset_entries).__name__}."
-        )
+    """Load miami2025 + instances COCO annotations and build Detectron2 dicts."""
+    with open(json_file, "r") as f:
+        miami = json.load(f)
+    with open(inst_json, "r") as f:
+        inst = json.load(f)
 
-    instance_content = _load_json_file(inst_json)
-    if not isinstance(instance_content, dict):
-        raise ValueError(
-            f"Expected a dict of instance annotations in {inst_json}, got {type(instance_content).__name__}."
-        )
+    id2ann, id2img = _build_id_maps(inst)
 
-    annotations_map: Dict[int, Dict[str, Any]] = {
-        ann["id"]: ann for ann in instance_content.get("annotations", [])
+    # Map logical split -> actual image subdir
+    split_to_dir = {
+        "train": "train2014",
+        "val":   "val2014",
+        "testA": "val2014",
+        "testB": "val2014",
     }
-    images_map: Dict[int, Dict[str, Any]] = {
-        img["id"]: img for img in instance_content.get("images", [])
-    }
+    subdir = split_to_dir.get(target_split, "val2014")
 
-    dataset_dicts: List[Dict[str, Any]] = []
-    for entry in dataset_entries:
-        if entry.get("split") != target_split:
+    data: List[Dict[str, Any]] = []
+    missing_anns = 0
+    for item in miami:
+        if item.get("split") != target_split:
             continue
 
-        file_name = entry.get("file_name")
-        if not file_name:
-            LOGGER.warning("Skipping entry without file_name: %s", entry)
-            continue
+        file_name = item["file_name"]
+        image_id = item["image_id"]
+        ann_ids  = item.get("ann_id", [])
+        cat_ids  = item.get("category_id", [])
+        ref_id   = item.get("ref_id", None)
+        sent     = item.get("sentences", [{}])[0].get("sent", "")
 
-        image_id = entry.get("image_id")
-        record: Dict[str, Any] = {
-            "file_name": os.path.join(image_root, target_split, file_name),
-            "image_id": image_id,
-        }
-
-        image_meta = images_map.get(image_id) if image_id is not None else None
-        record["height"] = _safe_get(image_meta or {}, "height")
-        record["width"] = _safe_get(image_meta or {}, "width")
-
-        sentences = entry.get("sentences") or []
-        sentence_text = ""
-        if sentences:
-            first_sentence = sentences[0]
-            if isinstance(first_sentence, dict):
-                sentence_text = first_sentence.get("sent", "")
-            else:
-                sentence_text = str(first_sentence)
-        record["sentence"] = sentence_text
-        record["ref_id"] = entry.get("ref_id")
-
-        ann_ids = _ensure_iterable(entry.get("ann_id", []))
-        merged_ann: Optional[Dict[str, Any]] = None
-        for ann_id in ann_ids:
-            annotation = annotations_map.get(int(ann_id)) if ann_id is not None else None
-            if annotation is None:
-                LOGGER.warning(
-                    "[miami2025] Missing annotation id %s for image %s", ann_id, image_id
-                )
-                continue
-
-            if merged_ann is None:
-                merged_ann = {
-                    "iscrowd": annotation.get("iscrowd", 0),
-                    "category_id": annotation.get("category_id", 0),
-                    "segmentation": [],
-                }
-
-            segmentation = annotation.get("segmentation")
-            if segmentation:
-                if isinstance(segmentation, list):
-                    merged_ann["segmentation"].extend(segmentation)
+        # Merge polygons of all referred instance ids
+        seg_list = []
+        for aid in ann_ids:
+            ann = id2ann.get(aid)
+            if ann and "segmentation" in ann:
+                seg = ann["segmentation"]
+                if isinstance(seg, list):
+                    seg_list += seg
                 else:
-                    merged_ann["segmentation"].append(segmentation)
+                    seg_list.append(seg)
+            else:
+                missing_anns += 1
 
-        category = entry.get("category_id")
-        if isinstance(category, list):
-            category = category[0] if category else 0
-        if merged_ann is not None:
-            merged_ann["category_id"] = category if category is not None else merged_ann.get("category_id", 0)
-            record["annotations"] = [merged_ann]
-        else:
-            record["annotations"] = []
+        # Get size if present in instances.json
+        height = width = None
+        img_meta = id2img.get(image_id)
+        if img_meta:
+            height, width = img_meta.get("height", None), img_meta.get("width", None)
 
-        dataset_dicts.append(record)
+        abs_path = os.path.join(image_root, subdir, file_name)
+        record = {
+            "file_name": abs_path,  # absolute path for safety
+            "image_id": image_id,
+            "height": height,
+            "width":  width,
+            "annotations": [{
+                "iscrowd": 0,
+                "category_id": cat_ids[0] if cat_ids else 0,
+                "segmentation": seg_list,
+            }],
+            "ref_id":  ref_id,
+            "sentence": sent,
+        }
+        data.append(record)
 
-    print(f"Loaded {len(dataset_dicts)} samples for miami2025_{target_split}.")
-    return dataset_dicts
+    print(f"[miami2025] Built {len(data)} samples for split '{target_split}' "
+          f"(missing_anns={missing_anns})")
+    return data
 
 
-def register_miami2025(root: str = "datasets/miami2025") -> None:
-    """Register the miami2025 dataset splits with Detectron2."""
-    dataset_json = _resolve_annotation_path(root, "miami2025.json")
-    if dataset_json is None:
-        raise FileNotFoundError(
-            f"Could not locate miami2025.json relative to root '{root}'."
-        )
+def register_miami2025(root: str = "/autodl-tmp/rela_data"):
+    """
+    Register miami2025 splits using the real AutoDL paths by default.
+    Environment override:
+      - MIAMI_INST_JSON: full path to instances.json
+    """
+    json_file = os.path.join(root, "annotations", "miami2025.json")
 
-    env_inst_json = os.getenv("MIAMI_INST_JSON")
-    inst_json: Optional[str] = None
-    if env_inst_json and os.path.isfile(env_inst_json):
-        inst_json = env_inst_json
-    elif env_inst_json:
-        LOGGER.warning(
-            "[miami2025] MIAMI_INST_JSON is set but file not found: %s", env_inst_json
-        )
-
-    if inst_json is None:
-        fallback = _resolve_annotation_path(root, "instances_sample.json")
-        if fallback is None:
-            fallback = _resolve_annotation_path(root, "instances.json")
-        if fallback is None:
-            raise FileNotFoundError(
-                "Could not locate instances annotation file (sample or real)."
-            )
-        inst_json = fallback
-        print(f"[miami2025] Using fallback instance annotation file: {inst_json}")
+    inst_json_env = os.environ.get("MIAMI_INST_JSON")
+    if inst_json_env and os.path.exists(inst_json_env):
+        inst_json = inst_json_env
+        print(f"[miami2025] Using instances from env: {inst_json}")
+    else:
+        inst_json = os.path.join(root, "annotations", "instances.json")
+        print(f"[miami2025] Using instances from default: {inst_json}")
 
     image_root = os.path.join(root, "images")
 
-    available_categories: List[str] = []
-    try:
-        instance_content = _load_json_file(inst_json)
-        available_categories = [
-            cat["name"]
-            for cat in instance_content.get("categories", [])
-            if "name" in cat
-        ]
-    except (OSError, json.JSONDecodeError):
-        LOGGER.warning(
-            "[miami2025] Unable to parse categories from %s", inst_json
-        )
+    # Helpful debug prints (kept short)
+    print(f"[miami2025] json_file={json_file}")
+    print(f"[miami2025] inst_json={inst_json}")
+    print(f"[miami2025] image_root={image_root}")
 
-    split_mapping = {
-        "train": "miami2025_train",
-        "val": "miami2025_val",
-        "testA": "miami2025_testA",
-        "testB": "miami2025_testB",
-    }
-
-    for split_key, dataset_name in split_mapping.items():
-        if dataset_name in DatasetCatalog.list():
-            continue
+    for split in ["train", "val", "testA", "testB"]:
+        name = f"miami2025_{split}"
         DatasetCatalog.register(
-            dataset_name,
-            lambda json_file=dataset_json,
+            name,
+            lambda s=split: load_miami2025_json(json_file, image_root, inst_json, s)
+        )
+        MetadataCatalog.get(name).set(
             image_root=image_root,
+            evaluator_type="refcoco",
+            json_file=json_file,
             inst_json=inst_json,
-            target_split=split_key: load_miami2025_json(
-                json_file, image_root, inst_json, target_split
-            ),
         )
-        metadata = MetadataCatalog.get(dataset_name)
-        metadata.set(
-            evaluator_type="refer",
-            image_root=os.path.join(image_root, split_key),
-            json_file=dataset_json,
-            instances_json=inst_json,
-        )
-        if available_categories:
-            metadata.set(thing_classes=available_categories)
 
 
-_default_root = os.path.join(os.getenv("DETECTRON2_DATASETS", "datasets"), "miami2025")
-register_miami2025(_default_root)
+# Auto-register on import
+register_miami2025()
 
 
 if __name__ == "__main__":
+    # Quick sanity check (no model build)
     from detectron2.data import DatasetCatalog
-
     for split in ["train", "val"]:
-        dataset_name = f"miami2025_{split}"
-        dataset = DatasetCatalog.get(dataset_name)
-        print(f"Split {split} sample count: {len(dataset)}")
-        if dataset:
-            first_sample = dataset[0]
-            print("Example keys:", list(first_sample.keys()))
-            print("Example file:", first_sample.get("file_name"))
-            print("Example sentence:", first_sample.get("sentence", ""))
+        ds = DatasetCatalog.get(f"miami2025_{split}")
+        print(f"[check] Split {split} count:", len(ds))
+        if ds:
+            print("[check] Example file:", ds[0]["file_name"])
+            print("[check] Example sentence:", ds[0].get("sentence", "")[:80])


### PR DESCRIPTION
## Summary
- replace the miami2025 dataset registration with the AutoDL data layout
- ensure instances.json can be overridden by environment variable and add debug prints

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4197817108326a386edfa4237a826