### PR TITLE
Robustify Miami2025 dataset bbox handling and validation

### DIFF
--- a/tools/validate_miami2025.py
+++ b/tools/validate_miami2025.py
@@ -1,0 +1,27 @@
+from detectron2.data import DatasetCatalog
+import os
+
+
+def check(name):
+    ds = DatasetCatalog.get(name)
+    miss_img = miss_keys = 0
+    for r in ds:
+        if not os.path.exists(r["file_name"]):
+            miss_img += 1
+        if "annotations" not in r or not r["annotations"]:
+            miss_keys += 1
+        else:
+            a = r["annotations"][0]
+            for k in ["segmentation", "bbox", "bbox_mode", "category_id"]:
+                if k not in a:
+                    miss_keys += 1
+                    break
+    print(f"[{name}] total={len(ds)} missing_images={miss_img} bad_annos={miss_keys}")
+
+
+if __name__ == "__main__":
+    for name in ["miami2025_train", "miami2025_val", "miami2025_testA", "miami2025_testB"]:
+        try:
+            check(name)
+        except KeyError:
+            print(f"[{name}] not registered, skip")

--- a/tools/validate_miami2025.py
+++ b/tools/validate_miami2025.py
@@ -1,3 +1,4 @@
+import datasets.register_miami2025  # noqa: F401
 from detectron2.data import DatasetCatalog
 import os
 


### PR DESCRIPTION
## Summary
- compute bounding boxes from polygons during Miami2025 dataset loading while skipping empty sentences and logging skip counts
- add a defensive bbox inference fallback in the RefCOCO mapper so training continues even when annotations lack boxes
- provide a validation utility script to audit Miami2025 dataset registrations for missing resources

## Testing
- `python datasets/register_miami2025.py` *(fails: ModuleNotFoundError: No module named 'detectron2' in this environment)*
- `python tools/validate_miami2025.py` *(fails: ModuleNotFoundError: No module named 'detectron2' in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e44f2597c48326896ece9025142d83