### PR TITLE
Add LQM configuration registration for LQMFormer

### DIFF
--- a/gres_model/config.py
+++ b/gres_model/config.py
@@ -3,6 +3,18 @@
 from detectron2.config import CfgNode as CN
 
 
+def add_lqm_config(cfg):
+    """Add LQM (Language-aware Query Modulation) configs to Detectron2 cfg."""
+
+    cfg.LQM = CN()
+    cfg.LQM.DQM = CN()
+    cfg.LQM.DQM.ENABLE = False
+    cfg.LQM.DQM.TOP_P = 0.2
+    cfg.LQM.DQM.NQ = 100
+    cfg.LQM.DQM.LOSS_WEIGHT = 1.0
+    cfg.LQM.DQM.SCORE_DIM = 256
+
+
 def add_maskformer2_config(cfg):
     """
     Add config for MASK_FORMER.
@@ -137,3 +149,9 @@ def add_refcoco_config(cfg):
     cfg.REFERRING = CN()
     cfg.REFERRING.BERT_TYPE = "bert-base-uncased"
     cfg.REFERRING.MAX_TOKENS = 20
+
+
+def add_gres_config(cfg):
+    add_maskformer2_config(cfg)
+    add_refcoco_config(cfg)
+    add_lqm_config(cfg)


### PR DESCRIPTION
## Summary
- add an add_lqm_config helper to register Language-aware Query Modulation defaults
- extend add_gres_config to include maskformer, RefCOCO, and LQM configuration blocks

## Testing
- python -m compileall gres_model/config.py
- python - <<'PY'
from detectron2.config import get_cfg
from gres_model.config import add_gres_config
cfg = get_cfg()
add_gres_config(cfg)
print(cfg.LQM.DQM)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e478450664832685441cb430556c28