### PR TITLE
Register GRES config before merging configs

### DIFF
--- a/train_net.py
+++ b/train_net.py
@@ -41,6 +41,8 @@ from detectron2.projects.deeplab import add_deeplab_config, build_lr_scheduler
 from detectron2.solver.build import maybe_add_gradient_clipping
 from detectron2.utils.logger import setup_logger
 
+from gres_model.config import add_gres_config
+
 # MaskFormer
 from gres_model import (
     RefCOCOMapper,
@@ -185,6 +187,7 @@ def setup(args):
     add_deeplab_config(cfg)
     add_maskformer2_config(cfg)
     add_refcoco_config(cfg)
+    add_gres_config(cfg)
     cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts)
     cfg.freeze()


### PR DESCRIPTION
## Summary
- import the GRES configuration registration helper in the training script
- register the custom GRES configuration keys before merging external config files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e47dcae69c832685d8f343d7ad0453