### PR TITLE
Refactor: remove all RefCOCO dependencies and enforce Miami2025 as the only dataset source.

### DIFF
--- a/configs/referring_miami2025_lqm.yaml
+++ b/configs/referring_miami2025_lqm.yaml
@@ -3,6 +3,13 @@ _BASE_: referring_miami2025.yaml
 MODEL:
   META_ARCHITECTURE: "LQMFormer"
 
+DATASETS:
+  TRAIN: ("miami2025_train",)
+  TEST: ("miami2025_val",)
+
+INPUT:
+  FORMAT: "RGB"
+
 LQM:
   DQM:
     ENABLE: True

--- a/gres_model/data/dataset_mappers/refcoco_mapper.py
+++ b/gres_model/data/dataset_mappers/refcoco_mapper.py
@@ -192,7 +192,35 @@ class RefCOCOMapper:
 
 
         # Language data
-        sentence_raw = dataset_dict['sentence']['raw']
+        dataset_name = dataset_dict.get("dataset_name", "") or ""
+        sentence_field = dataset_dict.get("sentence", "")
+
+        if "miami2025" in dataset_name:
+            if isinstance(sentence_field, dict):
+                sentence_raw = (
+                    sentence_field.get("raw")
+                    or sentence_field.get("sent")
+                    or ""
+                )
+            else:
+                sentence_raw = str(sentence_field)
+        else:
+            if isinstance(sentence_field, dict):
+                sentence_raw = sentence_field.get("raw", "")
+            else:
+                sentence_raw = str(sentence_field)
+
+        if not sentence_raw and dataset_dict.get("sentences"):
+            first_sentence = dataset_dict["sentences"][0]
+            if isinstance(first_sentence, dict):
+                sentence_raw = (
+                    first_sentence.get("raw")
+                    or first_sentence.get("sent")
+                    or ""
+                )
+            elif isinstance(first_sentence, str):
+                sentence_raw = first_sentence
+
         attention_mask = [0] * self.max_tokens
         padded_input_ids = [0] * self.max_tokens
 

--- a/gres_model/data/datasets/__init__.py
+++ b/gres_model/data/datasets/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from . import (
-    register_refcoco
-)
+from . import register_miami2025  # noqa: F401
+
+__all__ = ["register_miami2025"]

--- a/gres_model/data/datasets/register_miami2025.py
+++ b/gres_model/data/datasets/register_miami2025.py
@@ -1,0 +1,28 @@
+import os
+
+from detectron2.data import DatasetCatalog
+
+from datasets.register_miami2025 import register_miami2025 as _register_miami2025
+
+
+def _detect_root() -> str:
+    """Resolve the dataset root for Miami2025 registration."""
+    env_root = os.getenv("MIAMI2025_DATASETS")
+    if env_root:
+        return env_root
+    return os.getenv("DETECTRON2_DATASETS", "/autodl-tmp/rela_data")
+
+
+_root = _detect_root()
+_required = {"miami2025_train", "miami2025_val"}
+
+
+def _ensure_registration():
+    if not _required.issubset(set(DatasetCatalog.list())):
+        _register_miami2025(_root)
+
+
+_ensure_registration()
+
+
+__all__ = ["_ensure_registration"]

--- a/tools/validate_miami2025.py
+++ b/tools/validate_miami2025.py
@@ -1,6 +1,8 @@
-import datasets.register_miami2025  # noqa: F401
-from detectron2.data import DatasetCatalog
 import os
+
+from detectron2.data import DatasetCatalog
+
+from datasets.register_miami2025 import register_miami2025
 
 
 def check(name):
@@ -21,7 +23,12 @@ def check(name):
 
 
 if __name__ == "__main__":
-    for name in ["miami2025_train", "miami2025_val", "miami2025_testA", "miami2025_testB"]:
+    required = ("miami2025_train", "miami2025_val")
+
+    if not set(required).issubset(set(DatasetCatalog.list())):
+        register_miami2025()
+
+    for name in required:
         try:
             check(name)
         except KeyError:


### PR DESCRIPTION
## Summary
- replace RefCOCO dataset registration with a Miami2025-only workflow and add a helper that resolves dataset roots before registering
- ensure the Miami2025 loader annotates dataset names, tighten its registration defaults to train/val splits, and make the mapper resilient to string-based sentences
- align configs and validation tooling to the Miami2025 splits and RGB input expectations

## Testing
- python - <<'PY'
import gres_model.data.datasets  # noqa: F401
from detectron2.data import DatasetCatalog

print(sorted(DatasetCatalog.list()))
PY *(fails: ModuleNotFoundError: No module named 'detectron2')*


------
https://chatgpt.com/codex/tasks/task_e_68e4876c15508326b332511992cfc952