### PR TITLE
Add source metadata to Miami2025 dataset records

### DIFF
--- a/datasets/register_miami2025.py
+++ b/datasets/register_miami2025.py
@@ -243,6 +243,7 @@ def load_miami2025_json(
             "ref_id":  ref_id,
             "sentence": sent,
         }
+        record["source"] = "miami2025"
         if dataset_name:
             record["dataset_name"] = dataset_name
         data.append(record)


### PR DESCRIPTION
## Summary
- add the `source` key to each Miami2025 dataset record so the evaluator can access it

## Testing
- source ~/rela-env/bin/activate *(fails: No such file or directory)*
- python train_net.py --config-file configs/referring_miami2025_lqm.yaml --num-gpus 1 --eval-only MODEL.WEIGHTS swin_base_patch4_window12_384_22k.pkl *(fails: ModuleNotFoundError: No module named 'detectron2')*

------
https://chatgpt.com/codex/tasks/task_e_68e52dd1ed0083269364a916381220df