### PR TITLE
Ensure Miami2025 mapper preserves source field

### DIFF
--- a/gres_model/data/dataset_mappers/refcoco_mapper.py
+++ b/gres_model/data/dataset_mappers/refcoco_mapper.py
@@ -130,6 +130,7 @@ class RefCOCOMapper:
 
     def __call__(self, dataset_dict):
         dataset_dict = copy.deepcopy(dataset_dict)  # it will be modified by code below
+        _src = dataset_dict.get("source", "miami2025")
         image = utils.read_image(dataset_dict["file_name"], format=self.img_format)
         utils.check_image_size(dataset_dict, image)
 
@@ -233,5 +234,7 @@ class RefCOCOMapper:
 
         dataset_dict['lang_tokens'] = torch.tensor(padded_input_ids).unsqueeze(0)
         dataset_dict['lang_mask'] = torch.tensor(attention_mask).unsqueeze(0)
+
+        dataset_dict["source"] = _src
 
         return dataset_dict

--- a/tools/check_loader_has_source.py
+++ b/tools/check_loader_has_source.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Minimal smoke test to ensure Miami2025 loader preserves `source`."""
+
+import os
+
+
+def main():
+    try:
+        from detectron2.config import get_cfg
+        from detectron2.data import build_detection_test_loader
+    except ImportError:
+        print("detectron2 is not available; skipping loader check.")
+        return
+
+    from detectron2.projects.deeplab import add_deeplab_config
+
+    from gres_model import RefCOCOMapper, add_maskformer2_config, add_refcoco_config
+    from gres_model.config import add_gres_config
+
+    # Ensure datasets are registered
+    import datasets.register_miami2025  # noqa: F401
+
+    cfg = get_cfg()
+    add_deeplab_config(cfg)
+    add_maskformer2_config(cfg)
+    add_refcoco_config(cfg)
+    add_gres_config(cfg)
+
+    config_path = os.path.join(os.path.dirname(__file__), "..", "configs", "referring_miami2025_lqm.yaml")
+    cfg.merge_from_file(os.path.realpath(config_path))
+    cfg.freeze()
+
+    dataset_name = cfg.DATASETS.TEST[0]
+    mapper = RefCOCOMapper(cfg, is_train=False)
+    data_loader = build_detection_test_loader(cfg, dataset_name, mapper=mapper)
+
+    first_batch = next(iter(data_loader))
+    if not first_batch:
+        print("Received empty batch from loader.")
+        return
+
+    first_sample = first_batch[0]
+    print("Sample keys:", sorted(first_sample.keys()))
+    print("Sample source:", first_sample.get("source"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- preserve the `source` key when the RefCOCOMapper processes Miami2025 samples
- add a smoke test script to confirm the loader exposes the `source` field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5342355608326a046a764e55e49e3