### PR TITLE
Update Miami2025 config to use Swin base

### DIFF
--- a/configs/referring_miami2025.yaml
+++ b/configs/referring_miami2025.yaml
@@ -1,4 +1,4 @@
-_BASE_: referring_R50.yaml
+_BASE_: referring_swin_tiny.yaml
 
 MODEL:
   BACKBONE:


### PR DESCRIPTION
## Summary
- update the Miami2025 base config to inherit from the Swin Tiny configuration to avoid ResNet-only keys

## Testing
- python - <<'PY'
from detectron2.config import get_cfg
from gres_model.config import add_gres_config

cfg = get_cfg(); add_gres_config(cfg); cfg.merge_from_file("configs/referring_miami2025_lqm.yaml")
print("✅ Config merged successfully")
PY *(fails: ModuleNotFoundError: No module named 'detectron2')*

------
https://chatgpt.com/codex/tasks/task_e_68e53f0a0f988326bd61b1964a2cf8fd