### PR TITLE
Fix Swin config inheritance and LQM wiring for Miami2025 eval

### DIFF
--- a/configs/Base-Swin.yaml
+++ b/configs/Base-Swin.yaml
@@ -1,0 +1,57 @@
+MODEL:
+  BACKBONE:
+    FREEZE_AT: 0
+    NAME: "D2SwinTransformer"
+  SWIN:
+    EMBED_DIM: 96
+    DEPTHS: [2, 2, 6, 2]
+    NUM_HEADS: [3, 6, 12, 24]
+    WINDOW_SIZE: 7
+    APE: False
+    DROP_PATH_RATE: 0.3
+    PATCH_NORM: True
+  WEIGHTS: "models/swin_tiny_patch4_window7_224.pkl"
+  PIXEL_MEAN: [123.675, 116.280, 103.530]
+  PIXEL_STD: [58.395, 57.120, 57.375]
+
+DATASETS:
+  REF_ROOT: "refer/data/"
+  TRAIN: ("refcoco_unc_train",)
+  TEST: ("refcoco_unc_val",)
+
+REFERRING:
+  BERT_TYPE: "bert-base-uncased"
+
+SOLVER:
+  IMS_PER_BATCH: 16
+  BASE_LR: 0.0001
+  STEPS: (327778, 355092)
+  MAX_ITER: 368750
+  WARMUP_FACTOR: 1.0
+  WARMUP_ITERS: 10
+  WEIGHT_DECAY: 0.05
+  OPTIMIZER: "ADAMW"
+  BACKBONE_MULTIPLIER: 0.1
+  CLIP_GRADIENTS:
+    ENABLED: True
+    CLIP_TYPE: "full_model"
+    CLIP_VALUE: 0.01
+    NORM_TYPE: 2.0
+  AMP:
+    ENABLED: True
+
+INPUT:
+  IMAGE_SIZE: 384
+  MIN_SCALE: 0.75
+  MAX_SCALE: 1.0
+  FORMAT: "RGB"
+  DATASET_MAPPER_NAME: "refcoco"
+
+TEST:
+  EVAL_PERIOD: 5000
+
+DATALOADER:
+  FILTER_EMPTY_ANNOTATIONS: False
+  NUM_WORKERS: 4
+
+VERSION: 2

--- a/configs/referring_swin_tiny.yaml
+++ b/configs/referring_swin_tiny.yaml
@@ -1,4 +1,4 @@
-_BASE_: referring_R50.yaml
+_BASE_: Base-Swin.yaml
 MODEL:
   BACKBONE:
     NAME: "D2SwinTransformer"


### PR DESCRIPTION
## Summary
- add a clean Swin backbone base config that avoids MODEL.RESNETS keys
- retarget the Swin Tiny config to inherit from the new base so LQM configs merge cleanly

## Testing
- `python - <<'PY' ...` *(fails: detectron2 is unavailable in the execution environment)*
- `python datasets/register_miami2025.py` *(fails: detectron2 is unavailable in the execution environment)*
- `PYTHONPATH=. python tools/smoke_eval_miami2025.py`

------
https://chatgpt.com/codex/tasks/task_e_68e54987049c83268c645431491deb57