### PR TITLE
Fix Miami2025 mask decoding height alignment

### DIFF
--- a/datasets/miami2025_sample_instances_match.json
+++ b/datasets/miami2025_sample_instances_match.json
@@ -1,0 +1,38 @@
+[
+  {
+    "ann_id": [3007],
+    "category_id": [18],
+    "file_name": "COCO_train2014_000000098304.jpg",
+    "image_id": 98304,
+    "no_target": false,
+    "ref_id": 1,
+    "sentences": [
+      {"raw": "person near pole", "sent": "person near pole"}
+    ],
+    "split": "train"
+  },
+  {
+    "ann_id": [99893, 108703],
+    "category_id": [18, 1],
+    "file_name": "COCO_train2014_000000098304.jpg",
+    "image_id": 98304,
+    "no_target": false,
+    "ref_id": 2,
+    "sentences": [
+      {"raw": "multiple objects", "sent": "multiple objects"}
+    ],
+    "split": "train"
+  },
+  {
+    "ann_id": [-1],
+    "category_id": [],
+    "file_name": "COCO_train2014_000000098304.jpg",
+    "image_id": 98304,
+    "no_target": true,
+    "ref_id": 3,
+    "sentences": [
+      {"raw": "no target", "sent": "no target"}
+    ],
+    "split": "train"
+  }
+]


### PR DESCRIPTION
## Summary
- ensure RefCOCOMapper normalizes decode sizes from the transformed tensor while preserving the original image HW for fallback decoding
- skip negative annotation ids and carry original HW info forward in mask_status for targeted samples
- harden the offline smoke test so COCO image metadata yields usable original sizes and negative ids are skipped

## Testing
- python -m compileall gres_model/data/dataset_mappers/refcoco_mapper.py
- python -m compileall gres_model/utils/mask_ops.py
- python -m compileall gres_model/evaluation/refer_evaluation.py
- python -m compileall tools/smoke_eval_miami2025.py
- python tools/smoke_eval_miami2025.py --offline --split train --max-samples 5 --dataset-json datasets/miami2025_sample_instances_match.json --instances-json datasets/instances_sample.json
- python tools/smoke_eval_miami2025.py --unit-check

------
https://chatgpt.com/codex/tasks/task_e_68ebc3cedb708326923602f58e7f05d6